### PR TITLE
Result sort

### DIFF
--- a/src/fixed_segment.cr
+++ b/src/fixed_segment.cr
@@ -1,4 +1,7 @@
 module Amber::Router
+  # Represents a must-match url segment.
+  #
+  # In the url `/products/:23/*`, the first segment, `products` is a fixed segment.
   class FixedSegment(T) < Segment(T)
   end
 end

--- a/src/glob_segment.cr
+++ b/src/glob_segment.cr
@@ -1,4 +1,7 @@
 module Amber::Router
+  # Represents a "match anything" url segment.
+  #
+  # In the url `/products/:23/&lowast;`, the first segment, `&lowast;` is a glob segment.
   class GlobSegment(T) < Segment(T)
   end
 end

--- a/src/routed_result.cr
+++ b/src/routed_result.cr
@@ -1,7 +1,11 @@
 module Amber::Router
   class RoutedResult(T)
-    getter payload
-    def initialize(@payload : T?)
+    getter payload : T?
+
+    def initialize(terminal_segment : TerminalSegment(T)?)
+      if segment = terminal_segment
+        @payload = segment.route
+      end
     end
 
     def found?

--- a/src/terminal_segment.cr
+++ b/src/terminal_segment.cr
@@ -2,17 +2,22 @@ module Amber::Router
   class TerminalSegment(T)
     property route : T
     property full_path : String
+    property priority : Int32
 
     def initialize(@route, @full_path)
+      @priority = 0
+    end
+
+    def <(other : TerminalSegment(T))
+      @priority < other.priority
+    end
+
+    def <=(other : TerminalSegment(T))
+      @priority <= other.priority
     end
 
     def inspect(*, ts = 0)
-      "#{"  " * ts}|--(#{full_path})\n"
+      "#{"  " * ts}|--(#{full_path} P#{priority})\n"
     end
-
-    def to_s(i : IO)
-      i << "(terminal: #{full_path})"
-    end
-
   end
 end


### PR DESCRIPTION
Fixes a delicate bug where insertion order and routing order don't match up by sorting multiple matches by insertion order.

```crystal
route_set = Amber::Router::RouteSet(Symbol).new
route_set.add "/get/*/slug", :slug
route_set.add "/get/products/*/reviews", :amazon_style
route_set.add "/get/*", :catch_all

route_set.find("/get/products/amazing-spice-player/reviews").payload
# Before:
# => :catch_all
# After:
# => :amazon_style
```