### PR TITLE
Optional routing segments

### DIFF
--- a/spec/amber_router/parsers/optionals_spec.cr
+++ b/spec/amber_router/parsers/optionals_spec.cr
@@ -1,0 +1,54 @@
+require "../../spec_helper"
+
+describe "resolving optional segments in paths" do
+  it "does not alter paths without optionals" do
+    path = "/users/:id"
+    expected = [path]
+    actual = Amber::Router::Parsers::OptionalSegmentResolver.resolve(path)
+    actual.should eq expected
+  end
+
+  it "resolves one optional properly" do
+    path = "/users/:id(/children)/"
+    expected = [
+      "/users/:id/",
+      "/users/:id/children/"
+    ]
+    actual = Amber::Router::Parsers::OptionalSegmentResolver.resolve(path)
+    actual.should eq expected
+  end
+
+  it "resolves one nested optional properly" do
+    path = "/users/:id(/children(/grandchildren))/"
+    expected = [
+      "/users/:id/",
+      "/users/:id/children/",
+      "/users/:id/children/grandchildren/"
+    ]
+
+    actual = Amber::Router::Parsers::OptionalSegmentResolver.resolve(path)
+    actual.should eq expected
+  end
+
+  it "resolves two adjacent optionals properly" do
+    path = "/users/:id(/children)(/grandchildren)/"
+    expected = [
+      "/users/:id/",
+      "/users/:id/grandchildren/",
+      "/users/:id/children/",
+      "/users/:id/children/grandchildren/"
+    ]
+
+    actual = Amber::Router::Parsers::OptionalSegmentResolver.resolve(path)
+    actual.should eq expected
+  end
+
+  it "raises on mismatched parenthesis" do
+    path = "/users/(:id"
+
+    expect_raises Exception, /Could not find matching close parenthesis:/ do
+      Amber::Router::Parsers::OptionalSegmentResolver.resolve(path)
+    end
+  end
+
+end

--- a/spec/amber_router/route_set/matching/routes_with_optionals_spec.cr
+++ b/spec/amber_router/route_set/matching/routes_with_optionals_spec.cr
@@ -1,0 +1,15 @@
+require "../../../spec_helper"
+
+describe "routes with optional segments" do
+  it "routes two different paths declared with an optional segment" do
+    router = build do
+      add "/get/users(/:id/children)", :people_path
+    end
+
+    result = router.find "/get/users"
+    result.payload?.should eq :people_path
+
+    result = router.find "/get/users/3/children"
+    result.payload?.should eq :people_path
+  end
+end

--- a/src/amber/router/parsers/optionals.cr
+++ b/src/amber/router/parsers/optionals.cr
@@ -1,0 +1,173 @@
+module Amber::Router::Parsers
+  # Resolves "optional" segments in urls to many urls.
+  #
+  # In this class an optional is a parenthetical statement. For example, these
+  # urls all have one or more optional segments:
+  #
+  # - users/:id(.format)
+  # - relatives(/:id/children)
+  # - students(/peers(/teachers))
+  #
+  # This resolver pays no attention to url structure _other_ than parenthesis. As a result,
+  # care should be taken to properly structure optionals so that resolved urls are valid.
+  # It is easiest to maintain valid resolved urls by consistently placing delimiters relative
+  # to optional boundaries. For example:
+  #
+  # All optionals _begin_ with a delimiter: users/:id(/children(/grandchildren))/
+  # All optionals _end_ with a delimiter: users/:id/(children/(grandchildren/))
+  #
+  # Both examples produce the same result, which is this set of paths:
+  #
+  #     [
+  #       "users/:id/",
+  #       "users/:id/children/",
+  #       "users/:id/children/grandchildren/"
+  #     ]
+  #
+  # However, it is unwise to mix styles because it results in incorrect url delimiters.
+  #
+  # For example: users/:id(/children/(grandchildren/))/cousins
+  # Produces this set of paths:
+  #
+  #   [
+  #     "users/:id/cousins",
+  #     "users/:id/children//cousins",
+  #     "users/:id/children/grandchildren//cousins"
+  #   ]
+  #
+  class OptionalSegmentResolver
+
+    def self.necessary?(path : String) : Bool
+      path.includes? "(" || path.includes? ")"
+    end
+
+    # Converts a path url with parenthesis into a walkable array 
+    # of segments.
+    #
+    #  "users/:id(/children(/:gender))/grade/(:letter)"
+    #
+    #  [
+    #    "users/:id",  "(",  "/children",  "(",  "/:gender", ")", ")",
+    #    "/grade/",  "(",  ":letter",  ")"
+    #  ]
+    protected def segmentize(path : String) : Array(String)
+      current_segment = [] of String
+
+      segments = [] of String
+
+      path.split("").each do |c|
+        if c == "(" || c == ")"
+          segments << current_segment.join "" unless current_segment.empty?
+          segments << c
+          current_segment.clear
+        else
+          current_segment << c
+        end
+      end
+
+      segments << current_segment.join "" if current_segment.any?
+
+      segments
+    end
+
+    getter paths : Array(Array(String))
+
+    def initialize(path : String)
+      @paths = [] of Array(String)
+      @paths = [self.segmentize path]
+    end
+
+    def self.resolve(path : String) : Array(String)
+      instance = new path
+      instance.resolve
+      instance.paths.map &.join("")
+    end
+
+    # Iterates the path array until there are no more optionals to resolve,
+    # populating the @paths array with resolutions.
+    def resolve
+      loop do
+        index_of_path_with_optional = paths.index do |path|
+          path.includes? "("
+        end
+
+        break unless index_of_path_with_optional
+
+        new_paths = resolve_optional paths[index_of_path_with_optional]
+
+        paths[index_of_path_with_optional] = new_paths.shift
+
+        while new_paths.any?
+          paths.insert index_of_path_with_optional, new_paths.shift
+        end
+      end
+    end
+
+    # Converts a single path with at least one optional into
+    # two paths. One with the optional and one without.
+    #
+    # When a path has nested optionals, only the outermost optional is resolved.
+    def resolve_optional(path : Array(String)) : Array(Array(String))
+      optional_start = path.index "("
+
+      return [path] if optional_start.nil?
+
+      open_optionals = 0
+      optional_end = nil
+
+      position = optional_start + 1
+
+      while position < path.size
+        segment = path[position]
+
+        if segment == "("
+          open_optionals += 1
+
+        elsif segment == ")"
+          if open_optionals > 0
+            open_optionals -= 1
+          else
+            optional_end = position
+            break
+          end
+        end
+
+        position += 1
+      end
+
+      unless optional_end
+        carat_position = 0
+
+        path[0..optional_start].each do |segment|
+          carat_position += segment.size
+        end
+
+        indent = "  "
+
+        message = String.build do |error|
+          error << "\n"
+          error << "Could not find matching close parenthesis:\n"
+          error << indent
+          error << path.join("")
+          error << "\n"
+          error << indent
+          error << "~" * (carat_position - 1)
+          error << "^"
+          error << "\n"
+        end
+
+        raise message
+      end
+
+      route_with_optional = path[0...optional_start]
+      route_with_optional += path[(optional_start+1)...optional_end]
+      route_with_optional += path[(optional_end+1)..-1]
+
+      route_without_optional = [] of String
+      route_without_optional += path[0...optional_start]
+      route_without_optional += path[(optional_end+1)..-1]
+
+      [route_with_optional, route_without_optional]
+    end
+  end
+end

--- a/src/amber/router/route_set.cr
+++ b/src/amber/router/route_set.cr
@@ -61,10 +61,22 @@ module Amber::Router
 
     # Add a route to the tree.
     def add(path, payload : T) : Nil
-      segments = split_path path
-      terminal_segment = add(segments, payload, path)
-      terminal_segment.priority = @insert_count
-      @insert_count += 1
+      if path.includes?("(") || path.includes?(")")
+        paths = parse_subpaths path
+      else
+        paths = [path]
+      end
+
+      paths.each do |path|
+        segments = split_path path
+        terminal_segment = add(segments, payload, path)
+        terminal_segment.priority = @insert_count
+        @insert_count += 1
+      end
+    end
+
+    def parse_subpaths(path : String) : Array(String)
+      Parsers::OptionalSegmentResolver.resolve path
     end
 
     # Recursively find or create subtrees matching a given path, and store the

--- a/src/amber_router.cr
+++ b/src/amber_router.cr
@@ -5,3 +5,5 @@ require "./amber/router/route_set"
 require "./amber/router/routed_result"
 require "./amber/router/segment"
 require "./amber/router/glob_match"
+
+require "./amber/router/parsers/*"

--- a/src/usage_example.cr
+++ b/src/usage_example.cr
@@ -13,7 +13,7 @@ class RouteSetDemonstration
     add_route "/get/books/:id/chapters", :book_chapters
     add_route "/get/books/:id/authors", :book_authors
     add_route "/get/books/:id/pictures", :book_pictures
-    add_route "/get/users/:id/pictures", :users_pictures
+    add_route "/get/users/:id/pictures(/sorted)", :users_pictures
     add_route "/get/*/slug", :slug
     add_route "/get/products/*slug/reviews", :product_reviews
     add_route "/get/*", :catch_all
@@ -42,7 +42,7 @@ RouteSetDemonstration.new.tap do |rsd|
   puts "="*80
   puts "Rendering of route tree:"
   puts "="*80
-  p rsd.route_set
+  puts rsd.route_set.formatted_s
   puts "="*80
   puts
   puts
@@ -51,4 +51,6 @@ RouteSetDemonstration.new.tap do |rsd|
   rsd.find_and_check "/get/very/warm/winter/hat/slug", :slug
   rsd.find_and_check "/get/products/very/warm/winter/hat/reviews", :product_reviews
   rsd.find_and_check "/get/spa/yolo", :catch_all
+  rsd.find_and_check "/get/users/:id/pictures", :users_pictures
+  rsd.find_and_check "/get/users/:id/pictures/sorted", :users_pictures
 end


### PR DESCRIPTION
This allows the url router to accept definitions which include optional segments, and route them accordingly. All the resolution of the optional segments is done at route-definition time, so this does not affect the request-time efficiency at all.

Routes with an optional segment are resolved into more than one path and all inserted into the routing tree. For example:

```text
Adding route: /get/users/:id/pictures(/sorted) => users_pictures
================================================================================
Rendering of route tree:
================================================================================
  |--get
      |--users
          |--:id
              |--pictures
                  |--(/get/users/:id/pictures P0)
                  |--sorted
                      |--(/get/users/:id/pictures/sorted P1)
```