### PR TITLE
named matchers to adding routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ route_set.add "/get/*", :catch_all
 route_set.add "/get/posts/:page", :user_path, {"page" => /\d+/}
 route_set.add "/get/test/:id", :user_path, {"id" => /foo_\d/}
 
+# Supports named based argument constraints
+route_set.add "/get/posts/:page", :user_path, {"page" => :ascii}
+route_set.add "/get/test/:id", :user_path, {"id" => :integer}
+
 route_set.find("/get/posts/1").found? # => true
 route_set.find("/get/posts/foo").found? # => false
 

--- a/spec/amber_router/route_set/matching/routes_with_variables_spec.cr
+++ b/spec/amber_router/route_set/matching/routes_with_variables_spec.cr
@@ -41,6 +41,15 @@ describe "routes with variables" do
   it "routes with constraints" do
     router = build do
       # With symbol hash
+      add "/get/int/:page_num", :page_num, {:page_num => :integer}
+
+      # With symbol hash
+      add "/get/string/:page_name", :page_name, {:page_name => :ascii}
+
+      # With symbol hash
+      add "/get/uuid/:page_id", :page_id, {:page_id => :uuid}
+
+      # With symbol hash
       add "/get/posts/:page", :user_path, {:page => /\d+/}
 
       # With string hash
@@ -49,6 +58,15 @@ describe "routes with variables" do
       # with named tuple
       add "/get/time/:id", :user_path, {id: /\d:\d:\d/}
     end
+
+    router.find("/get/int/1").found?.should be_true
+    router.find("/get/int/foo").found?.should be_false
+
+    router.find("/get/string/foo").found?.should be_true
+    router.find("/get/string/☃︎").found?.should be_false
+
+    router.find("/get/uuid/87b3042b-9b9a-41b7-8b15-a93d3f17025e").found?.should be_true
+    router.find("/get/uuid/foo").found?.should be_false
 
     router.find("/get/posts/1").found?.should be_true
     router.find("/get/posts/foo").found?.should be_false

--- a/spec/amber_router/route_set/matching/routes_with_variables_spec.cr
+++ b/spec/amber_router/route_set/matching/routes_with_variables_spec.cr
@@ -58,8 +58,8 @@ describe "routes with variables" do
     router.find("/get/int/1").found?.should be_true
     router.find("/get/int/foo").found?.should be_false
 
-    router.find("/get/string/foo").found?.should be_true
-    router.find("/get/string/☃︎").found?.should be_false
+    router.find("/get/ascii/foo").found?.should be_true
+    router.find("/get/ascii/☃︎").found?.should be_false
 
     router.find("/get/uuid/87b3042b-9b9a-41b7-8b15-a93d3f17025e").found?.should be_true
     router.find("/get/uuid/foo").found?.should be_false

--- a/spec/amber_router/route_set/matching/routes_with_variables_spec.cr
+++ b/spec/amber_router/route_set/matching/routes_with_variables_spec.cr
@@ -42,7 +42,7 @@ describe "routes with variables" do
     router = build do
       # With named matcher
       add "/get/int/:page_num", :page_num, {:page_num => :integer}
-      add "/get/string/:page_name", :page_name, {:page_name => :ascii}
+      add "/get/ascii/:page_name", :page_name, {:page_name => :ascii}
       add "/get/uuid/:page_id", :page_id, {:page_id => :uuid}
 
       # With symbol hash

--- a/spec/amber_router/route_set/matching/routes_with_variables_spec.cr
+++ b/spec/amber_router/route_set/matching/routes_with_variables_spec.cr
@@ -40,13 +40,9 @@ describe "routes with variables" do
 
   it "routes with constraints" do
     router = build do
-      # With symbol hash
+      # With named matcher
       add "/get/int/:page_num", :page_num, {:page_num => :integer}
-
-      # With symbol hash
       add "/get/string/:page_name", :page_name, {:page_name => :ascii}
-
-      # With symbol hash
       add "/get/uuid/:page_id", :page_id, {:page_id => :uuid}
 
       # With symbol hash

--- a/src/amber/router/route_set.cr
+++ b/src/amber/router/route_set.cr
@@ -24,6 +24,8 @@ module Amber::Router
   # route_set.find("/get/posts/one").found? # => false
   # ```
   class RouteSet(T)
+    alias Constraints = Hash(String, Regex | Symbol)
+
     @trunk : RouteSet(T)?
     @route : T?
     @segments = [] of Segment(T) | TerminalSegment(T)
@@ -33,7 +35,7 @@ module Amber::Router
     end
 
     # Look for or create a subtree matching a given segment.
-    private def find_subtree!(segment : String, constraints : Hash(String, Regex | Symbol)) : Segment(T)
+    private def find_subtree!(segment : String, constraints : Constraints) : Segment(T)
       if subtree = find_subtree segment
         subtree
       else
@@ -158,7 +160,7 @@ module Amber::Router
       Parsers::OptionalSegmentResolver.resolve path
     end
 
-    private def add_route(path, payload : T, constraints : Hash(String, Regex | Symbol)) : Nil
+    private def add_route(path, payload : T, constraints : Constraints) : Nil
       if path.includes?('(') || path.includes?(')')
         paths = parse_subpaths path
       else
@@ -174,7 +176,7 @@ module Amber::Router
     end
 
     # Add a route to the tree.
-    def add(path, payload : T, constraints : Hash(String, Regex | Symbol) = {} of String => Regex) : Nil
+    def add(path, payload : T, constraints : Constraints = Constraints.new) : Nil
       add_route path, payload, constraints
     end
 
@@ -185,7 +187,7 @@ module Amber::Router
 
     # Recursively find or create subtrees matching a given path, and store the
     # application route at the leaf.
-    protected def add(url_segments : Array(String), route : T, full_path : String, constraints : Hash(String, Regex | Symbol)) : TerminalSegment(T)
+    protected def add(url_segments : Array(String), route : T, full_path : String, constraints : Constraints) : TerminalSegment(T)
       unless url_segments.any?
         segment = TerminalSegment(T).new(route, full_path)
         @segments.push segment

--- a/src/amber/router/route_set.cr
+++ b/src/amber/router/route_set.cr
@@ -33,7 +33,7 @@ module Amber::Router
     end
 
     # Look for or create a subtree matching a given segment.
-    private def find_subtree!(segment : String, constraints : Hash(String, Regex)) : Segment(T)
+    private def find_subtree!(segment : String, constraints : Hash(String, Regex | Symbol)) : Segment(T)
       if subtree = find_subtree segment
         subtree
       else
@@ -158,7 +158,7 @@ module Amber::Router
       Parsers::OptionalSegmentResolver.resolve path
     end
 
-    private def add_route(path, payload : T, constraints : Hash(String, Regex)) : Nil
+    private def add_route(path, payload : T, constraints : Hash(String, Regex | Symbol)) : Nil
       if path.includes?('(') || path.includes?(')')
         paths = parse_subpaths path
       else
@@ -174,18 +174,18 @@ module Amber::Router
     end
 
     # Add a route to the tree.
-    def add(path, payload : T, constraints : Hash(String, Regex) = {} of String => Regex) : Nil
+    def add(path, payload : T, constraints : Hash(String, Regex | Symbol) = {} of String => Regex) : Nil
       add_route path, payload, constraints
     end
 
     # ditto
-    def add(path, payload : T, constraints : Hash(Symbol, Regex) | NamedTuple) : Nil
+    def add(path, payload : T, constraints : Hash(Symbol, Regex | Symbol) | NamedTuple) : Nil
       add_route path, payload, constraints.to_h.transform_keys(&.to_s)
     end
 
     # Recursively find or create subtrees matching a given path, and store the
     # application route at the leaf.
-    protected def add(url_segments : Array(String), route : T, full_path : String, constraints : Hash(String, Regex)) : TerminalSegment(T)
+    protected def add(url_segments : Array(String), route : T, full_path : String, constraints : Hash(String, Regex | Symbol)) : TerminalSegment(T)
       unless url_segments.any?
         segment = TerminalSegment(T).new(route, full_path)
         @segments.push segment

--- a/src/amber/router/segments/variable_segment.cr
+++ b/src/amber/router/segments/variable_segment.cr
@@ -1,12 +1,19 @@
 module Amber::Router
   class VariableSegment(T) < Segment(T)
-    def initialize(segment, @pattern : Regex? = nil)
+    def initialize(segment, @pattern : (Regex | Symbol)? = nil)
       super segment
     end
 
     def match?(segment : String) : Bool
-      if pattern = @pattern
-        !(segment =~ pattern).nil?
+      case @pattern
+      when :integer
+        match_integer?(segment)
+      when :uuid
+        match_uuid?(segment)
+      when :ascii
+        segment.ascii_only?
+      when Regex
+        !(segment =~ @pattern).nil?
       else
         true
       end
@@ -18,6 +25,23 @@ module Amber::Router
 
     def parameter : String
       segment[1..-1]
+    end
+
+    private def match_integer?(segment : String) : Bool
+      segment.each_byte do |byte|
+        return false unless 48 <= byte <= 57
+      end
+      true
+    end
+
+    # This is a port of https://github.com/crystal-lang/crystal/blob/master/src/uuid.cr#L79
+    private def match_uuid?(segment)
+      return false if segment.bytesize != 36
+      {8, 13, 18, 23}.each { |offset| return false if segment[offset] != '-' }
+      {0, 2, 4, 6, 9, 11, 14, 16, 19, 21, 24, 26, 28, 30, 32, 34}.each do |offset|
+        return false unless (ch1 = segment[offset].to_u8?(16)) && (ch2 = segment[offset + 1].to_u8?(16))
+      end
+      true
     end
   end
 end

--- a/src/amber/router/segments/variable_segment.cr
+++ b/src/amber/router/segments/variable_segment.cr
@@ -39,7 +39,7 @@ module Amber::Router
       return false if segment.bytesize != 36
       {8, 13, 18, 23}.each { |offset| return false if segment[offset] != '-' }
       {0, 2, 4, 6, 9, 11, 14, 16, 19, 21, 24, 26, 28, 30, 32, 34}.each do |offset|
-        return false unless (ch1 = segment[offset].to_u8?(16)) && (ch2 = segment[offset + 1].to_u8?(16))
+        return false unless (segment[offset].to_u8?(16)) && (segment[offset + 1].to_u8?(16))
       end
       true
     end


### PR DESCRIPTION
This change adds paramaters to adding routes to check for common use cases.  Specifically you can add routes that check for integers, ascii, and uuids.
```crystal
route_set = Amber::Router::RouteSet(Symbol).new
route_set.add "/get/pages/:page_num", :page_num, {:page_num => :integer}
route_set.add "/get/page_name/:page_name", :page_name, {:page_name => :ascii}
route_set.add "/get/page_uuid/:page_id", :page_id, {:page_id => :uuid}
```
I have checked the perfomance of these matchers and all are more performant then their regex counterparts, some are way faster.  But this change is intended to make the patterns more decalritive and understandable.

### Integer
```crystal
require "benchmark"
Benchmark.ips do |x|
  x.report("integer regex") do
    /\d+/ =~ "123"
  end

  x.report("integer matcher") do
    "123".each_byte do |byte|
      next unless 48 <= byte <= 57
    end
  end
end
```

```bash
$ crystal int_match.cr --release
  integer regex  10.11M ( 98.93ns) (± 2.06%)  16 B/op  54.88× slower
integer matcher 554.78M (   1.8ns) (± 4.40%)   0 B/op        fastest
```

### Ascii
```crystal
require "benchmark"
Benchmark.ips do |x|
  x.report("ascii regex") do
    /[^\w]+/ =~ "foo123"
  end

  x.report("ascii matcher") do
    "foo123".ascii_only?
  end
end
```

```bash
$ crystal ascii_match.cr --release
  ascii regex  15.64M ( 63.94ns) (± 2.33%)  16 B/op  30.29× slower
ascii matcher 473.69M (  2.11ns) (± 3.61%)   0 B/op        fastest
```

### UUID
```crystal
require "benchmark"
Benchmark.ips do |x|
  x.report("uuid regex") do
    /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/ =~ "87b3042b-9b9a-41b7-8b15-a93d3f17025e"
  end

  x.report("uuid matcher") do
    segment = "87b3042b-9b9a-41b7-8b15-a93d3f17025e"
    next if segment.bytesize != 36
    {8, 13, 18, 23}.each { |offset| next if segment[offset] != '-' }
    {0, 2, 4, 6, 9, 11, 14, 16, 19, 21, 24, 26, 28, 30, 32, 34}.each do |offset|
      next unless (ch1 = segment[offset].to_u8?(16)) && (ch2 = segment[offset + 1].to_u8?(16))
    end
  end
end

```

```bash
$ crystal uuid_match.cr --release
  uuid regex   3.75M (266.68ns) (±24.79%)  16 B/op   1.69× slower
uuid matcher   6.34M (157.84ns) (±21.00%)   0 B/op        fastest
```