### PR TITLE
Support curly params

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ route_set.add "get/curly/{named_param}", :curly_param
 # Which would be equivalent to
 route_set.add "get/colon/:named_param", :named_param
 
-
 # A `*` at the start of a segment indicates a glob parameter
 route_set.add "/get/users/comments/*date_range"
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ route_set.add "/get/", :root
 route_set.add "/get/users/:id", :users
 route_set.add "/get/users/:id/books", :users_books
 
+# Can also use '{}' to denote a named parameter
+route_set.add "get/curly/{named_param}", :curly_param
+
+# Which would be equivalent to
+route_set.add "get/colon/:named_param", :named_param
+
+
 # A `*` at the start of a segment indicates a glob parameter
 route_set.add "/get/users/comments/*date_range"
 
@@ -70,39 +77,42 @@ result.params # => {"post_name" => "my_trip_to_kansas"}
 $ crystal run examples/benchmark.cr --release
 
 /get/
-amber_router: root   3.63M (275.23ns) (± 5.58%)  546 B/op   1.44× slower
-       radix: root   5.25M (190.49ns) (± 4.07%)  320 B/op        fastest
+amber_router: root   4.23M (236.34ns) (± 2.88%)  482 B/op   1.22× slower
+       radix: root   5.15M (194.13ns) (± 9.87%)  320 B/op        fastest
 
 /get/books/23/chapters
-amber_router: deep   1.73M (578.29ns) (± 4.25%)  1040 B/op        fastest
-       radix: deep   1.54M ( 647.9ns) (± 5.46%)   592 B/op   1.12× slower
+amber_router: deep   1.64M (609.75ns) (± 8.70%)  963 B/op        fastest
+       radix: deep   1.54M (651.03ns) (± 3.74%)  592 B/op   1.07× slower
 
 /get/books/23/pages
-amber_router: wrong   2.46M (406.07ns) (± 1.50%)  768 B/op        fastest
-       radix: wrong   1.85M ( 541.1ns) (± 2.09%)  513 B/op   1.33× slower
+amber_router: wrong    2.3M ( 435.1ns) (± 3.99%)  691 B/op        fastest
+       radix: wrong   1.72M (582.98ns) (± 7.82%)  513 B/op   1.34× slower
 
 /get/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z
-amber_router: many segments 475.73k (   2.1µs) (± 3.78%)  4498 B/op   4.31× slower
-       radix: many segments   2.05M (488.09ns) (± 1.28%)   448 B/op        fastest
+amber_router: many segments 505.91k (  1.98µs) (± 2.65%)  4225 B/op   3.75× slower
+       radix: many segments    1.9M (526.61ns) (± 8.41%)   448 B/op        fastest
 
 /get/var/2/3/4/5/6/7/8/9/0/1/2/3/4/5/6/7/8/9/0/1/2/3/4/5/6
-amber_router: many variables 276.63k (  3.61µs) (± 4.65%)  6517 B/op   1.44× slower
-       radix: many variables 397.75k (  2.51µs) (± 1.67%)  2853 B/op        fastest
+amber_router: many variables 276.65k (  3.61µs) (± 8.11%)  6246 B/op   1.49× slower
+       radix: many variables 412.46k (  2.42µs) (± 1.27%)  2849 B/op        fastest
 
 /get/foobarbizfoobarbizfoobarbizfoobarbizfoobarbizbat/3
-amber_router: long segments   1.83M (546.36ns) (± 2.03%)  912 B/op        fastest
-       radix: long segments   1.19M ( 842.9ns) (± 1.46%)  624 B/op   1.54× slower
+amber_router: long segments   1.85M (541.47ns) (± 3.52%)  834 B/op        fastest
+       radix: long segments   1.04M (963.47ns) (± 8.53%)  624 B/op   1.78× slower
 
 /post/products/23/reviews/
-amber_router: catchall route    2.2M (455.48ns) (± 1.13%)  896 B/op   1.66× slower
-       radix: catchall route   3.65M (274.33ns) (± 4.71%)  449 B/op        fastest
+amber_router: catchall route   2.25M (443.73ns) (± 9.34%)  800 B/op   1.63× slower
+       radix: catchall route   3.67M (272.69ns) (± 1.46%)  448 B/op        fastest
 
 /put/products/Winter-Windproof-Trapper-Hat/dp/B01J7DAMCQ
-globs with suffix match   1.18M (845.37ns) (± 1.27%)  1489 B/op  fastest
+globs with suffix match   1.18M (843.95ns) (± 8.16%)  1392 B/op  fastest
 
 Route constraints
-   route with a valid constraint 1.84M (544.55ns) (± 1.11%)  912 B/op   1.31× slower
-route with an invalid constraint 2.41M (414.72ns) (± 1.25%)  672 B/op        fastest
+   route with a valid constraint    1.7M ( 587.7ns) (±10.01%)  835 B/op   1.45× slower
+route with an invalid constraint   2.47M (405.38ns) (± 1.97%)  593 B/op        fastest
+
+Curly params
+matches correctly    1.7M ( 587.4ns) (± 8.06%)  855 B/op  fastest
 ```
 
 ## Contributing

--- a/examples/benchmark.cr
+++ b/examples/benchmark.cr
@@ -94,13 +94,25 @@ class Benchmarker
     # Add a route with a requirement
     amber_router.add "/get/test/:id", :requirement_path, {:id => /foo_\d/}
 
-    puts "Route constraints".colorize(:yellow).bold
+    puts "Route constraints".colorize(:white).bold
     Benchmark.ips do |x|
       x.report("route with a valid constraint") do
         run_check(amber_router, "/get/test/foo_99", :requirement_path)
       end
       x.report("route with an invalid constraint") do
         run_check(amber_router, "/get/test/foo_bar", nil)
+      end
+    end
+
+    puts
+
+    # Add a route with a curly param
+    amber_router.add "/get/curly/{id}", :curly_path
+
+    puts "Curly params".colorize(:white).bold
+    Benchmark.ips do |x|
+      x.report("matches correctly") do
+        run_check(amber_router, "/get/curly/foo_99", :curly_path)
       end
     end
   end

--- a/spec/amber_router/route_set/matching/routes_with_variables_spec.cr
+++ b/spec/amber_router/route_set/matching/routes_with_variables_spec.cr
@@ -59,4 +59,29 @@ describe "routes with variables" do
     router.find("/get/test/foo_7").found?.should be_true
     router.find("/get/test/foo_").found?.should be_false
   end
+
+  it "routes with curly brace variables" do
+    router = build do
+      add "/curly/{id}", :simple
+      add "/curly/user/{user_id}", :constraint, {"user_id" => /foo_\d/}
+      add "/curly/var/{b}/{c}/{d}/{e}/{f}/{g}/{h}/{i}/{j}/{k}/{l}/{m}/{n}/{o}/{p}/{q}/{r}/{s}/{t}/{u}/{v}/{w}/{x}/{y}/{z}", :variable_alphabet
+    end
+
+    simple_route = router.find("/curly/123")
+    simple_route.found?.should be_true
+    simple_route.payload?.should eq :simple
+    simple_route.params["id"].should eq "123"
+
+    constraint_route = router.find("/curly/user/123")
+    constraint_route.found?.should be_false
+
+    constraint_route = router.find("/curly/user/foo_123")
+    constraint_route.found?.should be_true
+    constraint_route.payload?.should eq :constraint
+    constraint_route.params["user_id"].should eq "foo_123"
+
+    long_route = router.find("/curly/var/2/3/4/5/6/7/8/9/0/1/2/3/4/5/6/7/8/9/0/1/2/3/4/5/6")
+    long_route.found?.should be_true
+    long_route.payload?.should eq :variable_alphabet
+  end
 end

--- a/src/amber/router/route_set.cr
+++ b/src/amber/router/route_set.cr
@@ -38,8 +38,10 @@ module Amber::Router
         subtree
       else
         case segment
-        when .starts_with? ':'
+        when .starts_with?(':')
           new_segment = VariableSegment(T).new(segment, constraints[segment.lchop(':')]?)
+        when .starts_with? '{'
+          new_segment = VariableSegment(T).new(segment, constraints[segment.lchop('{').rchop('}')]?)
         when .starts_with? '*'
           new_segment = GlobSegment(T).new(segment)
         else

--- a/src/amber/router/segments/variable_segment.cr
+++ b/src/amber/router/segments/variable_segment.cr
@@ -17,7 +17,11 @@ module Amber::Router
     end
 
     def parameter : String
-      segment[1..-1]
+      if segment.starts_with?('{') && segment.ends_with?('}')
+        segment.lchop('{').rchop('}')
+      else
+        segment.lchop(':')
+      end
     end
   end
 end


### PR DESCRIPTION
The [OpenAPI spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#path-templating) uses curly braces to denote named path params.  I think the router should support this.
