### PR TITLE
Add method to return array of matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ route_set.find("/get/posts/foo").found? # => false
 route_set.find("/get/test/foo_7").found? # => true
 route_set.find("/get/test/foo_").found? # => false
 
+# Supports returning an array of matches.
+# Allows using custom logic based on each route's payload
+# to determine if a match could be found
+route_set.add "/user/:id", :user_get
+route_set.add "/user/:id", :user_delete
+route_set.add "/user/:id/posts", :user_posts_get
+
+route_set.find_routes("/user/10").map &.payload? # => [:user_get, :user_delete]
+
 # Finding routes from a payload:
 route_set.find("/get/users/3").payload # => :users
 route_set.find("/get/users/3/books").payload # => :users_books

--- a/spec/amber_router/route_set/route_set_spec.cr
+++ b/spec/amber_router/route_set/route_set_spec.cr
@@ -1,0 +1,19 @@
+require "../../spec_helper"
+
+describe Amber::Router::RouteSet do
+  describe "#find_routes" do
+    it "returns an array of matches" do
+      route_set = build do
+        add "foo/bar", :foo_bar
+        add "foo", :foo_get
+        add "foo", :foo_post
+        add "foo", :foo_delete
+      end
+
+      matches = route_set.find_routes("foo")
+      matches.size.should eq 3
+
+      matches.map(&.payload?).should eq [:foo_get, :foo_post, :foo_delete]
+    end
+  end
+end

--- a/src/amber_router/route_set.cr
+++ b/src/amber_router/route_set.cr
@@ -147,6 +147,11 @@ module Amber::Router
       end
     end
 
+    # Returns the routes which are compatible with the provided *path*.
+    def find_routes(path : String) : Array(RoutedResult(T))
+      select_routes split_path path
+    end
+
     # Produces a readable, indented rendering of the tree.
     def formatted_s(*, ts = 0)
       @segments.reduce("") do |str, segment|


### PR DESCRIPTION
Adds a public method that works similar to `#find`, but returns an `Array(RoutedResult(T))`.

My use case is for Athena.  I want to be able to support differentiating 405s and 404s.  With this PR, I would be able to do something like:

```cr
matches = @router.find_routes request.path

raise ART::Exceptions::NotFound.new "No route found for '#{request.method} #{request.path}'" if matches.empty?

if route = matches.find(&.payload.not_nil!.method.==(request.method.upcase))
  route
else
  allowed_methods = matches.map(&.payload.not_nil!.method).join(',')

  raise ART::Exceptions::MethodNotAllowed.new "No route found for '#{request.method} #{request.path}': Method not allowed (Allow: #{allowed_methods})"
end
```