### PR TITLE
Preparations for Crystal 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: amber_router
-version: 0.4.2
+version: 0.4.3
 
 authors:
   - Robert L Carpenter <robert@robacarp.com>
@@ -7,10 +7,10 @@ authors:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.12.0
+    version: ~> 0.13.0
   radix:
     github: luislavena/radix
 
-crystal: 0.31.1
+crystal: '>= 0.35.0'
 
 license: MIT


### PR DESCRIPTION
Prepares the router for Crystal `1.0.0`:
  * Sets `crystal` property to allow anything greater than `0.35.0`, as ATM the router is uninstallable on nightly
  * Bumps Ameba to `0.13.x`
  * Bumps patch on router version