### PR TITLE
updated crystal version to 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,6 +11,6 @@ development_dependencies:
   radix:
     github: luislavena/radix
 
-crystal: '>= 0.35.0'
+crystal: '>= 1.0.0'
 
 license: MIT


### PR DESCRIPTION
updated the crystal version to 1.0.0 to resolve the issue of updating the amber version:`crystal (>= 0.35.0)` required by `amber_router 0.4.4`